### PR TITLE
implemented `Data.streamfrom` for `Data.field`

### DIFF
--- a/src/Arrow.jl
+++ b/src/Arrow.jl
@@ -36,10 +36,11 @@ immutable Date
 end
 
 const UNIXEPOCH_DT = Dates.value(Dates.Date(1970))
-function unix2date(x)
-    rata = UNIXEPOCH_DT + x.value
+function unix2date(x::Integer)
+    rata = UNIXEPOCH_DT + x
     return Dates.Date(Dates.UTD(rata))
 end
+unix2date(x::Arrow.Date) = unix2date(x.value)
 date2unix(x::Dates.Date) = (Dates.value(x) - UNIXEPOCH_DT) % Int32
 
 Base.convert(::Type{Dates.Date}, x::Arrow.Date) = unix2date(x.value)

--- a/src/Feather.jl
+++ b/src/Feather.jl
@@ -471,7 +471,7 @@ function writenulls(io, A::DataArray, null_count, len, total_bytes)
     # write out null bitmask
     if null_count > 0
         null_bytes = Feather.bytes_for_bits(len)
-        bytes = BitArray(!A.na)
+        bytes = BitArray(.!A.na)
         total_bytes = writepadded(io, view(reinterpret(UInt8, bytes.chunks), 1:null_bytes))
     end
     return total_bytes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,3 +139,4 @@ if VERSION < v"0.6.0"
 end
 include("datastreams.jl")
 end
+


### PR DESCRIPTION
Ok, this still has a couple of issues (in particular, I haven't yet figured out how to properly deserialize the `Bool`s), but it is a good start.  This allows you to pull individual fields without loading the whole file (at least I know it does that in the case where memory mapping is used, not quite sure what happens otherwise).

"But ExpandingMan, clearly the right thing to do is to implement the ability to pull arbitrarily small subsets of rows from columns, and the `Data.Field` implementation should be based on that."
Well, yes, true, but unfortunately the `DataStreams` interface standard doesn't support that yet (I think), though it should definitely be expanded to.  As is, there is a hell of a lot of extra overhead in pulling individual fields.  It'll be pretty simple to implement pulling subsets of columns once it is added to the standard.  The `Data.Field` stuff I wrote will still be useful (and on a personal note, it helped me to learn more about how these types of formats work).

Ok, if you guys can let me know how this can be improved, I'd be happy to make some changes so that this can be merged.  At the moment, I think that the only problem is with the `Bool`s.  Thanks!