### PR TITLE
Added random access streamfrom field methods

### DIFF
--- a/src/Arrow.jl
+++ b/src/Arrow.jl
@@ -10,43 +10,49 @@ struct Millisecond end
 struct Microsecond end
 struct Nanosecond end
 
+abstract type ArrowTimeType end
+
+value(x) = x
+value(x::Dates.TimeType) = Dates.value(x)
+value(x::ArrowTimeType) = x.value
+
 # Timestamp type with time unit `P` and timezone `Z`
-struct Timestamp{P,Z}
+struct Timestamp{P,Z} <: ArrowTimeType
     value::Int64
 end
 
 const UNIXEPOCH_TS = Dates.value(DateTime(1970)) #Rata Die milliseconds for 1970-01-01T00:00:00
 
-scale(::Type{Second}, x) = 1000 * x.value
-scale(::Type{Millisecond}, x) = x.value
-scale(::Type{Microsecond}, x) = div(x.value,1000)
-scale(::Type{Nanosecond}, x) =  div(x.value,1000000)
+scale(::Type{Second}, x) = 1000 * value(x)
+scale(::Type{Millisecond}, x) = value(x)
+scale(::Type{Microsecond}, x) = div(value(x),1000)
+scale(::Type{Nanosecond}, x) =  div(value(x),1000000)
 
 function unix2datetime(::Type{P}, x) where P
     rata = UNIXEPOCH_TS + scale(P, x)
     return DateTime(Dates.UTM(rata))
 end
-datetime2unix(x::DateTime) = Dates.value(x) - UNIXEPOCH_TS
+datetime2unix(x::DateTime) = value(x) - UNIXEPOCH_TS
 
 Base.convert(::Type{DateTime}, x::Timestamp{P,Z}) where {P, Z} = unix2datetime(P, x)
 Base.show(io::IO, x::Timestamp) = show(io, convert(DateTime,x))
 
-struct Date
+struct Date <: ArrowTimeType
     value::Int32
 end
 
 const UNIXEPOCH_DT = Dates.value(Dates.Date(1970))
 function unix2date(x)
-    rata = UNIXEPOCH_DT + x.value
+    rata = UNIXEPOCH_DT + value(x)
     return Dates.Date(Dates.UTD(rata))
 end
-date2unix(x::Dates.Date) = (Dates.value(x) - UNIXEPOCH_DT) % Int32
+date2unix(x::Dates.Date) = (value(x) - UNIXEPOCH_DT) % Int32
 
 Base.convert(::Type{Dates.Date}, x::Arrow.Date) = unix2date(x.value)
 Base.show(io::IO, x::Arrow.Date) = show(io, convert(Dates.Date,x))
 
 # Exact Time type with time unit `P`
-struct Time{P}
+struct Time{P} <: ArrowTimeType
     value::Int64
 end
 

--- a/src/Feather.jl
+++ b/src/Feather.jl
@@ -1,3 +1,5 @@
+__precompile__(true)
+
 module Feather
 
 using FlatBuffers, Nulls, WeakRefStrings, CategoricalArrays, DataStreams, DataFrames
@@ -129,9 +131,10 @@ function Source(file::AbstractString; nullable::Bool=false, weakrefstrings::Bool
 end
 
 # DataStreams interface
-# TODO allocate not defined in current version of DataStreams
-# Data.allocate(::Type{CategoricalValue{T, R}}, rows, ref) where {T, R} = CategoricalArray{T, 1, R}(rows)
-# Data.allocate(::Type{Union{CategoricalValue{T, R}, Null}}, rows, ref) where {T, R} = CategoricalArray{Union{T, Null}, 1, R}(rows)
+allocate(::Type{T}, rows, ref) where {T} = Vector{T}(rows)
+allocate(::Type{T}, rows, ref) where {T <: Union{WeakRefString,Null}} = WeakRefStringArray(ref, T, rows)
+allocate(::Type{CategoricalValue{T, R}}, rows, ref) where {T, R} = CategoricalArray{T, 1, R}(rows)
+allocate(::Type{Union{CategoricalValue{T, R}, Null}}, rows, ref) where {T, R} = CategoricalArray{Union{T, Null}, 1, R}(rows)
 
 Data.schema(source::Feather.Source) = source.schema
 Data.reference(source::Feather.Source) = source.data

--- a/src/Feather.jl
+++ b/src/Feather.jl
@@ -461,7 +461,7 @@ writevalue(io, val::T) where {T} = Base.write(io, string(val))
 writevalue(io, val::Null) = 0
 writevalue(io, val::String) = Base.write(io, val)
 
-function writecolumn(io, ::Type{T}, arr::Union{Vector{T}, Vector{Union{Null, T}}}) where {T <: Union{Vector{UInt8}, AbstractString}}
+function writecolumn(io, ::Type{T}, arr::Union{WeakRefStringArray{WeakRefString{UInt8}}, Vector{T}, Vector{Union{Null, T}}}) where {T <: Union{Vector{UInt8}, AbstractString}}
     len = length(arr)
     off = 0
     offsets = zeros(Int32, len + 1)

--- a/src/Feather.jl
+++ b/src/Feather.jl
@@ -437,9 +437,15 @@ end
 function writecolumn(io, ::Type{Date}, A)
     return writepadded(io, map(Arrow.date2unix, A))
 end
+function writecolumn(io, ::Type{Date}, A::Vector{Union{Null, Date}})
+    writepadded(io, map(x->(isnull(x) ? zero(Int32) : Arrow.date2unix(x)), A))
+end
 # Timestamp
 function writecolumn(io, ::Type{DateTime}, A)
     return writepadded(io, map(Arrow.datetime2unix, A))
+end
+function writecolumn(io, ::Type{DateTime}, A::Vector{Union{Null, DateTime}})
+    writepadded(io, map(x->(isnull(x) ? zero(Int64) : Arrow.datetime2unix(x)), A))
 end
 # other primitive T
 writecolumn(io, ::Type{T}, A::Vector{Union{Null, T}}) where {T} = writecolumn(io, T, map(x->ifelse(isnull(x),zero(T),x), A))

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -41,7 +41,7 @@ mutable struct TimeMetadata
     unit::TimeUnit
 end
 
-@UNION TypeMetadata Union{Void,CategoryMetadata,TimestampMetadata,DateMetadata,TimeMetadata}
+@UNION TypeMetadata (Void,CategoryMetadata,TimestampMetadata,DateMetadata,TimeMetadata)
 
 mutable struct Column
     name::String


### PR DESCRIPTION
I have changed the `Data.streamfrom` methods for `Data.Field` to do random access of the memory mapped data rather than pull entire columns.

I'm still doing something stupid with the `Bool`s as I still am not too sure how to do it properly.

There is a fair amount of overhead involved with computing pointers for individual fields, but nevertheless this still seems pretty fast.