### PR TITLE
Some CI tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ os:
 
 julia:
   - 1.0
+  - 1.1
   - nightly
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ julia> Pkg.add("Feather")
 
 ## Project Status
 
-The package is tested against Julia `0.6` and `0.7` on Linux, OS X, and Windows.
+The package is tested against Julia `1.0` and `1.1` on Linux, OS X, and Windows.
 
 ## Contributing and Questions
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 *Julia library for working with feather-formatted files*
 
-| **Documentation**                                                               | **PackageEvaluator**                                            | **Build Status**                                                                                |
-|:-------------------------------------------------------------------------------:|:---------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][pkg-0.6-img]][pkg-0.6-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
+| **Documentation**                                                               | **Build Status**                                                                                |
+|:-------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
+| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
 
 
 ## Installation
@@ -48,10 +48,3 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 [codecov-url]: https://codecov.io/gh/JuliaData/Feather.jl
 
 [issues-url]: https://github.com/JuliaData/Feather.jl/issues
-
-[pkg-0.4-img]: http://pkg.julialang.org/badges/Feather_0.4.svg
-[pkg-0.4-url]: http://pkg.julialang.org/?pkg=Feather
-[pkg-0.5-img]: http://pkg.julialang.org/badges/Feather_0.5.svg
-[pkg-0.5-url]: http://pkg.julialang.org/?pkg=Feather
-[pkg-0.6-img]: http://pkg.julialang.org/badges/Feather_0.6.svg
-[pkg-0.6-url]: http://pkg.julialang.org/?pkg=Feather

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 [travis-url]: https://travis-ci.org/JuliaData/Feather.jl
 
 [appveyor-img]: https://ci.appveyor.com/api/projects/status/nyybu2t2ofln4rn6/branch/master?svg=true
-[appveyor-url]: https://ci.appveyor.com/project/quinnj/feather-jl
+[appveyor-url]: https://ci.appveyor.com/project/quinnj/feather-jl-xxi09
 
 [codecov-img]: https://codecov.io/gh/JuliaData/Feather.jl/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/JuliaData/Feather.jl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,9 @@ platform:
 
 # # Uncomment the following lines to allow failures on nightly julia
 # # (tests will run but not make your overall status red)
- matrix:
-   allow_failures:
-   - julia_version: nightly
+matrix:
+  allow_failures:
+    - julia_version: nightly
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,9 @@ platform:
 
 # # Uncomment the following lines to allow failures on nightly julia
 # # (tests will run but not make your overall status red)
-# matrix:
-#   allow_failures:
-#   - julia_version: nightly
+ matrix:
+   allow_failures:
+   - julia_version: nightly
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,23 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 1.0
+  - julia_version: 1.1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
     - master
-
-matrix:
- allow_failures:
- - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
- - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+    - /release-.*/
 
 notifications:
   - provider: Email
@@ -21,24 +26,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# If there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo(); import Pkg;
-      Pkg.clone(pwd(), \"Feather\"); Pkg.build(\"Feather\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "import Pkg; Pkg.test(\"Feather\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"


### PR DESCRIPTION
- Package was not tested on 1.1
- Package was not tested on 1.0 and 1.1 on Windows.
- Documentation said it was tested on 0.6 and 0.7.
- The AV badge was linked to some old AV run that was last updated a year ago.

- The AV badge image url is likely wrong but I think you need AV access to get the correct url.