### PR TITLE
CI updates for Julia 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ os:
 julia:
   - 1.0
   - 1.1
+  - 1.2
   - nightly
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
   matrix:
   - julia_version: 1.0
   - julia_version: 1.1
+  - julia_version: 1.2
   - julia_version: nightly
 
 platform:


### PR DESCRIPTION
There seem to be no issues on either Feather or Arrow in Julia 1.2, all tests pass successfully.

I'm not sure if travis is quite ready for 1.2, if not we can just wait to merge.