### PR TITLE
throw error when trying to write column of eltype Missing

### DIFF
--- a/src/sink.jl
+++ b/src/sink.jl
@@ -39,6 +39,11 @@ function getarrow(col::AbstractVector{Union{T, Missing}}) where {T}
     hasmissing = any(ismissing, col)
     return arrowformat(hasmissing ? col : convert(AbstractVector{T}, col))
 end
+function getarrow(col::AbstractVector{Missing})
+    throw(ArgumentError("Feather format does not support writing `AbstractVector{Missing}`. "*
+                        "Consider converting column to `AbstractVector{Union{T,Missing}}` where "*
+                        "`T` is a supported type."))
+end
 
 function Metadata.PrimitiveArray(A::ArrowVector{J}, off::Integer, nbytes::Integer) where J
     Metadata.PrimitiveArray(feathertype(J), Metadata.PLAIN, off, length(A), nullcount(A), nbytes)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,6 +81,12 @@ GC.gc(); GC.gc()
     rm("testfile.feather")
 end
 
+@testset "issue#124" begin
+    df = DataFrame(A=rand(5), B=missings(5))
+    @test_throws ArgumentError Feather.write("test124.feather", df)
+    isfile("test124.feather") && rm("test124.feather")
+end
+
 if DO_PYTHON_ROUNDTRIP
 
 @testset "PythonRoundtrip" begin


### PR DESCRIPTION
Handles #124 by throwing an `ArgumentError` when trying to write a column of type `AbstractVector{Missing}` with a suggestion on how to handle it.